### PR TITLE
feat: Add Partner Setup Page with multi-step plant creation process

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import MentorsPage from "./routes/mentor/MentorPage";
 import ChatsPage from "./routes/chats/ChatsPage";
 import IndividualChatPage from "./routes/chats/userChat/UserChatPage";
 import GroupChatPage from "./routes/chats/groupChat/GroupChatPage";
+import UchinoKoSetupPage from "./routes/partner/setup/PartnerSetupPage";
+import PartnerPage from "./routes/partner/PartnerPage";
 
 function AppContent() {
   const location = useLocation();
@@ -37,6 +39,8 @@ function AppContent() {
         <Route path="/chats" element={<ChatsPage />} />
         <Route path="/chats/:id" element={<IndividualChatPage />} />
         <Route path="/group/:id" element={<GroupChatPage />}/>
+        <Route path="/partner/setup" element={<UchinoKoSetupPage />} />
+        <Route path="/partner" element={<PartnerPage />} />
       </Routes>
     </>
   );

--- a/src/hooks/usePlant.ts
+++ b/src/hooks/usePlant.ts
@@ -72,10 +72,15 @@ export const usePlant = () => {
 export const useRegisterPlant = () => {
     const [loading, setLoading] = useState<boolean>(false);
     const [error, setError] = useState<string | null>(null);
+    const token = localStorage.getItem("token");
 
     const registerPlant = async (plantData: {
         growth_stage: string;
         mood: string;
+        plant_name: string;
+        color: string;
+        size: number;
+        motivation_style: string;
     }) => {
         setLoading(true);
         setError(null);
@@ -84,7 +89,7 @@ export const useRegisterPlant = () => {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${localStorage.getItem('token')}`,
+                    Authorization: `Bearer ${token}`,
                 },
                 body: JSON.stringify(plantData),
             });

--- a/src/routes/partner/PartnerPage.module.css
+++ b/src/routes/partner/PartnerPage.module.css
@@ -316,7 +316,7 @@
 .formField { display: flex; flex-direction: column; gap: 0.5rem; } /* Shadcn: space-y-2 */
 .formLabel { font-size: 0.875rem; font-weight: 500; } /* Shadcn: text-sm font-medium (for label text) */
 .formInput, .formSelect { 
-  width: 100%;
+  width: auto;
   height: 2.5rem;
   padding: 0 0.75rem;
   border: 1px solid var(--input-border-color);
@@ -354,4 +354,31 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
+}
+
+/* Plant Preview */
+.plantPreviewContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-p-8);
+}
+
+.plantPreviewOuter {
+  position: relative;
+  margin-bottom: var(--spacing-4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px; /* rounded-full */
+}
+
+.plantPreviewInner {
+  border-radius: 9999px; /* rounded-full */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem; /* text-4xl */
+  color: var(--background); /* Icon color inside colored circle */
 }

--- a/src/routes/partner/PartnerPage.tsx
+++ b/src/routes/partner/PartnerPage.tsx
@@ -1,10 +1,12 @@
-import React, { useState, useEffect, useRef } from 'react';
-import styles from './PartnerPage.module.css';
+import React, { useState, useEffect, useRef } from "react";
+import styles from "./PartnerPage.module.css";
+import { usePlant } from "../../hooks/usePlant";
+import { plantTypes, personalities } from "../../types/plantType";
 
 // --- インターフェース定義 ---
 interface Message {
   text: string;
-  sender: 'user' | 'plant';
+  sender: "user" | "plant";
   time: string;
 }
 
@@ -30,25 +32,40 @@ interface GrowthMilestoneItem {
 }
 
 // --- カスタムコンポーネント (Shadcn UIのProgress代替) ---
-const CustomProgressBar: React.FC<{ value: number; barClassName?: string }> = ({ value, barClassName }) => {
+const CustomProgressBar: React.FC<{ value: number; barClassName?: string }> = ({
+  value,
+  barClassName,
+}) => {
   return (
     <div className={styles.progressBarContainer}>
-      <div className={`${styles.progressBarFill} ${barClassName || ''}`} style={{ width: `${Math.max(0, Math.min(100, value))}%` }} />
+      <div
+        className={`${styles.progressBarFill} ${barClassName || ""}`}
+        style={{ width: `${Math.max(0, Math.min(100, value))}%` }}
+      />
     </div>
   );
 };
 
 // --- メインコンポーネント ---
 export default function PartnerPage() {
-  const [partnerName, setPartnerName] = useState("モリモリ");
-  const [partnerLevel, setPartnerLevel] = useState(5);
-  const [partnerGrowth, setPartnerGrowth] = useState(45);
-  const [partnerPersonality, setPartnerPersonality] = useState("励まし屋");
+  const { plant } = usePlant();
   const [messages, setMessages] = useState<Message[]>([
-    { text: "おはよう！今日も一緒に頑張ろうね！", sender: "plant", time: "9:00" },
+    {
+      text: "おはよう！今日も一緒に頑張ろうね！",
+      sender: "plant",
+      time: "9:00",
+    },
     { text: "今日はどんな勉強をする予定？", sender: "plant", time: "9:01" },
-    { text: "Reactのコンポーネント設計について勉強したいと思ってるよ", sender: "user", time: "9:05" },
-    { text: "いいね！Reactは楽しいよ。わからないことがあったら、いつでも質問してね！", sender: "plant", time: "9:06" },
+    {
+      text: "Reactのコンポーネント設計について勉強したいと思ってるよ",
+      sender: "user",
+      time: "9:05",
+    },
+    {
+      text: "いいね！Reactは楽しいよ。わからないことがあったら、いつでも質問してね！",
+      sender: "plant",
+      time: "9:06",
+    },
   ]);
   const [newMessage, setNewMessage] = useState("");
   const [activeTab, setActiveTab] = useState("chat");
@@ -61,16 +78,50 @@ export default function PartnerPage() {
     { subject: "情報処理試験", percentage: 10 },
   ];
   const calendarEventsData: CalendarEventItem[] = [
-    { id: 'ev1', title: "Reactコンポーネント設計", time: "今日 15:00" },
-    { id: 'ev2', title: "二分探索木の実装", time: "明日 10:00" },
-    { id: 'ev3', title: "情報処理試験対策", time: "水曜日 13:00" },
+    { id: "ev1", title: "Reactコンポーネント設計", time: "今日 15:00" },
+    { id: "ev2", title: "二分探索木の実装", time: "明日 10:00" },
+    { id: "ev3", title: "情報処理試験対策", time: "水曜日 13:00" },
   ];
   const growthMilestonesData: GrowthMilestoneItem[] = [
-    { id: 'gm1', level: 1, time: "2週間前", iconHeight: "1.5rem", iconWidth: "1.5rem" },
-    { id: 'gm2', level: 2, time: "10日前", iconHeight: "1.75rem", iconWidth: "1.75rem" },
-    { id: 'gm3', level: 3, time: "1週間前", iconHeight: "2rem", iconWidth: "2rem" },
-    { id: 'gm4', level: 4, time: "3日前", iconHeight: "2rem", iconWidth: "2rem", leafHeight: "0.5rem", leafWidth: "1rem" },
-    { id: 'gm5', level: 5, time: "昨日", iconHeight: "2rem", iconWidth: "2rem", leafHeight: "0.75rem", leafWidth: "1.25rem" },
+    {
+      id: "gm1",
+      level: 1,
+      time: "2週間前",
+      iconHeight: "1.5rem",
+      iconWidth: "1.5rem",
+    },
+    {
+      id: "gm2",
+      level: 2,
+      time: "10日前",
+      iconHeight: "1.75rem",
+      iconWidth: "1.75rem",
+    },
+    {
+      id: "gm3",
+      level: 3,
+      time: "1週間前",
+      iconHeight: "2rem",
+      iconWidth: "2rem",
+    },
+    {
+      id: "gm4",
+      level: 4,
+      time: "3日前",
+      iconHeight: "2rem",
+      iconWidth: "2rem",
+      leafHeight: "0.5rem",
+      leafWidth: "1rem",
+    },
+    {
+      id: "gm5",
+      level: 5,
+      time: "昨日",
+      iconHeight: "2rem",
+      iconWidth: "2rem",
+      leafHeight: "0.75rem",
+      leafWidth: "1.25rem",
+    },
   ];
 
   useEffect(() => {
@@ -81,27 +132,37 @@ export default function PartnerPage() {
 
   const handleSendMessage = () => {
     if (newMessage.trim()) {
-      setMessages(prev => [
+      setMessages((prev) => [
         ...prev,
         {
           text: newMessage,
           sender: "user",
-          time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+          time: new Date().toLocaleTimeString([], {
+            hour: "2-digit",
+            minute: "2-digit",
+          }),
         },
       ]);
       setNewMessage("");
       setTimeout(() => {
         const responses = [
-          "その調子！頑張ってるね！", "素晴らしい進捗だね！", "何か困ったことはある？",
-          "今日の学習目標は達成できそう？", "休憩も大切だよ！無理しないでね。",
+          "その調子！頑張ってるね！",
+          "素晴らしい進捗だね！",
+          "何か困ったことはある？",
+          "今日の学習目標は達成できそう？",
+          "休憩も大切だよ！無理しないでね。",
         ];
-        const randomResponse = responses[Math.floor(Math.random() * responses.length)];
-        setMessages(prev => [
+        const randomResponse =
+          responses[Math.floor(Math.random() * responses.length)];
+        setMessages((prev) => [
           ...prev,
           {
             text: randomResponse,
             sender: "plant",
-            time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+            time: new Date().toLocaleTimeString([], {
+              hour: "2-digit",
+              minute: "2-digit",
+            }),
           },
         ]);
       }, 1000);
@@ -109,7 +170,36 @@ export default function PartnerPage() {
   };
 
   const handleSaveCustomization = () => {
-    alert(`カスタマイズ情報:\n名前: ${partnerName}\n性格: ${partnerPersonality}\nレベル: ${partnerLevel}\n成長度: ${partnerGrowth}%\n（保存処理は未実装です）`);
+    alert(`カスタマイズ情報`);
+  };
+
+  const getPlantPreview = () => {
+    const selectedType = plantTypes.find(
+      (type) => type.id === plant?.growth_stage
+    );
+    return (
+      <div className={styles.plantPreviewContainer}>
+        <div
+          className={styles.plantPreviewOuter}
+          style={{
+            width: `${(plant?.size ?? 100) + 50}px`,
+            height: `${(plant?.size ?? 100) + 50}px`,
+            backgroundColor: `${plant?.color}20`,
+          }}
+        >
+          <div
+            className={styles.plantPreviewInner}
+            style={{
+              width: `${plant?.size}px`,
+              height: `${plant?.size}px`,
+              backgroundColor: plant?.color,
+            }}
+          >
+            {selectedType?.icon || "🌱"}
+          </div>
+        </div>
+      </div>
+    );
   };
 
   return (
@@ -119,7 +209,9 @@ export default function PartnerPage() {
           <div className={styles.titleSection}>
             <div>
               <h1 className={styles.titleTextH1}>うちのコ (パートナー)</h1>
-              <p className={styles.titleTextP}>あなたのパートナーと一緒に成長しましょう</p>
+              <p className={styles.titleTextP}>
+                あなたのパートナーと一緒に成長しましょう
+              </p>
             </div>
           </div>
 
@@ -129,32 +221,40 @@ export default function PartnerPage() {
               <div className={styles.card}>
                 <div className={styles.cardHeader}>
                   <h2 className={styles.cardTitle}>プロフィール</h2>
-                  <p className={styles.cardDescription}>あなたのパートナー情報</p>
+                  <p className={styles.cardDescription}>
+                    あなたのパートナー情報
+                  </p>
                 </div>
-                <div className={`${styles.cardContent} ${styles.profileCardContent}`}>
+                <div
+                  className={`${styles.cardContent} ${styles.profileCardContent}`}
+                >
                   <div className={styles.plantVisualContainer}>
-                    <div className={styles.plantPotBase}></div>
-                    <div className={styles.plantPot}></div>
-                    <div className={styles.plantStem}></div>
+                    {getPlantPreview()}
                   </div>
-                  <h3 className={styles.partnerName}>{partnerName}</h3>
-                  <p className={styles.partnerLevel}>レベル: {partnerLevel}</p>
+                  <h3 className={styles.partnerName}>{plant?.plant_name}</h3>
+                  <p className={styles.partnerLevel}>レベル:</p>
                   <div className={styles.statRowContainer}>
                     <div className={styles.statRowInner}>
                       <div className={styles.statLabelContainer}>
                         <span className={styles.statLabel}>成長度</span>
-                        <span className={styles.statValue}>{partnerGrowth}%</span>
+                        <span className={styles.statValue}>100%</span>
                       </div>
-                      <CustomProgressBar value={partnerGrowth} />
+                      <CustomProgressBar value={100} />
                     </div>
                   </div>
-                  <div className={styles.statRowContainer} style={{ marginTop: '1rem' }}>
-                     <div className={styles.statRowInner}>
-                        <div className={styles.statLabelContainer}>
-                            <span className={styles.statLabel}>性格</span>
-                            <span className={styles.statValue}>{partnerPersonality}</span>
-                        </div>
-                     </div>
+                  <div
+                    className={styles.statRowContainer}
+                    style={{ marginTop: "1rem" }}
+                  >
+                    <div className={styles.statRowInner}>
+                      <div className={styles.statLabelContainer}>
+                        <span className={styles.statLabel}>性格</span>
+                        <span className={styles.statValue}>
+                          {personalities.find((p) => p.id === plant?.mood)
+                            ?.name || "性格未設定"}
+                        </span>
+                      </div>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -167,11 +267,15 @@ export default function PartnerPage() {
                 </div>
                 <div className={styles.cardContent}>
                   <div className={styles.learningStatusGrid}>
-                    {learningProgressData.map(item => (
+                    {learningProgressData.map((item) => (
                       <div key={item.subject} className={styles.progressItem}>
                         <div className={styles.statLabelContainer}>
-                          <span className={styles.statLabel}>{item.subject}</span>
-                          <span className={styles.statValue}>{item.percentage}%</span>
+                          <span className={styles.statLabel}>
+                            {item.subject}
+                          </span>
+                          <span className={styles.statValue}>
+                            {item.percentage}%
+                          </span>
                         </div>
                         <CustomProgressBar value={item.percentage} />
                       </div>
@@ -188,18 +292,24 @@ export default function PartnerPage() {
                 </div>
                 <div className={styles.cardContent}>
                   <div className={styles.calendarList}>
-                    {calendarEventsData.map(event => (
+                    {calendarEventsData.map((event) => (
                       <div key={event.id} className={styles.calendarItem}>
                         <div className={styles.calendarIconContainer}>
                           {/* public/icons/calendar.svg を配置してください */}
                           <img src="/icons/calendar.svg" alt="" />
                         </div>
                         <div>
-                          <h3 className={styles.calendarItemTextH3}>{event.title}</h3>
-                          <p className={styles.calendarItemTextP}>{event.time}</p>
+                          <h3 className={styles.calendarItemTextH3}>
+                            {event.title}
+                          </h3>
+                          <p className={styles.calendarItemTextP}>
+                            {event.time}
+                          </p>
                         </div>
-                        <button className={`${styles.iconButton} ${styles.calendarItemButton}`}>
-                           {/* public/icons/chevron-right.svg を配置してください */}
+                        <button
+                          className={`${styles.iconButton} ${styles.calendarItemButton}`}
+                        >
+                          {/* public/icons/chevron-right.svg を配置してください */}
                           <img src="/icons/chevron-right.svg" alt="View" />
                         </button>
                       </div>
@@ -213,42 +323,68 @@ export default function PartnerPage() {
             <div>
               <div className={styles.tabsList}>
                 <button
-                  className={`${styles.tabTrigger} ${activeTab === 'chat' ? styles.tabTriggerActive : ''}`}
-                  onClick={() => setActiveTab('chat')}
+                  className={`${styles.tabTrigger} ${
+                    activeTab === "chat" ? styles.tabTriggerActive : ""
+                  }`}
+                  onClick={() => setActiveTab("chat")}
                 >
                   チャット
                 </button>
                 <button
-                  className={`${styles.tabTrigger} ${activeTab === 'growth' ? styles.tabTriggerActive : ''}`}
-                  onClick={() => setActiveTab('growth')}
+                  className={`${styles.tabTrigger} ${
+                    activeTab === "growth" ? styles.tabTriggerActive : ""
+                  }`}
+                  onClick={() => setActiveTab("growth")}
                 >
                   成長記録
                 </button>
                 <button
-                  className={`${styles.tabTrigger} ${activeTab === 'customize' ? styles.tabTriggerActive : ''}`}
-                  onClick={() => setActiveTab('customize')}
+                  className={`${styles.tabTrigger} ${
+                    activeTab === "customize" ? styles.tabTriggerActive : ""
+                  }`}
+                  onClick={() => setActiveTab("customize")}
                 >
                   カスタマイズ
                 </button>
               </div>
 
-              {activeTab === 'chat' && (
+              {activeTab === "chat" && (
                 <div className={styles.tabContent}>
                   <div className={styles.card}>
                     <div className={styles.cardHeader}>
-                      <h2 className={styles.cardTitle}>{partnerName}とチャット</h2>
-                      <p className={styles.cardDescription}>あなたのパートナーと会話しましょう</p>
+                      <h2 className={styles.cardTitle}>
+                        {plant?.plant_name}とチャット
+                      </h2>
+                      <p className={styles.cardDescription}>
+                        あなたのパートナーと会話しましょう
+                      </p>
                     </div>
                     <div className={styles.cardContent}>
                       <div className={styles.chatArea} ref={chatAreaRef}>
                         {messages.map((message, index) => (
                           <div
                             key={index}
-                            className={`${styles.messageRow} ${message.sender === 'user' ? styles.messageRowUser : styles.messageRowPlant}`}
+                            className={`${styles.messageRow} ${
+                              message.sender === "user"
+                                ? styles.messageRowUser
+                                : styles.messageRowPlant
+                            }`}
                           >
-                            <div className={`${styles.messageBubble} ${message.sender === 'user' ? styles.messageBubbleUser : styles.messageBubblePlant}`}>
+                            <div
+                              className={`${styles.messageBubble} ${
+                                message.sender === "user"
+                                  ? styles.messageBubbleUser
+                                  : styles.messageBubblePlant
+                              }`}
+                            >
                               <p>{message.text}</p>
-                              <p className={`${styles.messageTime} ${message.sender === 'user' ? styles.messageTimeUser : styles.messageTimePlant}`}>
+                              <p
+                                className={`${styles.messageTime} ${
+                                  message.sender === "user"
+                                    ? styles.messageTimeUser
+                                    : styles.messageTimePlant
+                                }`}
+                              >
                                 {message.time}
                               </p>
                             </div>
@@ -262,9 +398,14 @@ export default function PartnerPage() {
                           className={styles.chatInput}
                           value={newMessage}
                           onChange={(e) => setNewMessage(e.target.value)}
-                          onKeyDown={(e) => e.key === "Enter" && handleSendMessage()}
+                          onKeyDown={(e) =>
+                            e.key === "Enter" && handleSendMessage()
+                          }
                         />
-                        <button onClick={handleSendMessage} className={`${styles.iconButton} ${styles.sendButton}`}>
+                        <button
+                          onClick={handleSendMessage}
+                          className={`${styles.iconButton} ${styles.sendButton}`}
+                        >
                           {/* public/icons/message-square.svg を配置してください */}
                           <img src="/icons/message-square.svg" alt="Send" />
                         </button>
@@ -274,33 +415,50 @@ export default function PartnerPage() {
                 </div>
               )}
 
-              {activeTab === 'growth' && (
+              {activeTab === "growth" && (
                 <div className={styles.tabContent}>
                   <div className={styles.card}>
                     <div className={styles.cardHeader}>
                       <h2 className={styles.cardTitle}>成長記録</h2>
-                      <p className={styles.cardDescription}>あなたのパートナーの成長履歴</p>
+                      <p className={styles.cardDescription}>
+                        あなたのパートナーの成長履歴
+                      </p>
                     </div>
                     <div className={styles.cardContent}>
                       <div className={styles.calendarList}>
-                        {growthMilestonesData.map(milestone => (
-                          <div key={milestone.id} className={styles.calendarItem}>
+                        {growthMilestonesData.map((milestone) => (
+                          <div
+                            key={milestone.id}
+                            className={styles.calendarItem}
+                          >
                             <div className={styles.growthRecordIconContainer}>
                               <div
                                 className={styles.growthPlantIcon}
-                                style={{ height: milestone.iconHeight, width: milestone.iconWidth }}
+                                style={{
+                                  height: milestone.iconHeight,
+                                  width: milestone.iconWidth,
+                                }}
                               >
-                                {milestone.leafHeight && milestone.leafWidth && (
-                                   <div
-                                     className={styles.growthPlantIconLeaf}
-                                     style={{ height: milestone.leafHeight, width: milestone.leafWidth, marginTop: '0.2rem' }}
-                                   ></div>
-                                )}
+                                {milestone.leafHeight &&
+                                  milestone.leafWidth && (
+                                    <div
+                                      className={styles.growthPlantIconLeaf}
+                                      style={{
+                                        height: milestone.leafHeight,
+                                        width: milestone.leafWidth,
+                                        marginTop: "0.2rem",
+                                      }}
+                                    ></div>
+                                  )}
                               </div>
                             </div>
                             <div>
-                              <h3 className={styles.calendarItemTextH3}>{`レベル${milestone.level}達成`}</h3>
-                              <p className={styles.calendarItemTextP}>{milestone.time}</p>
+                              <h3
+                                className={styles.calendarItemTextH3}
+                              >{`レベル${milestone.level}達成`}</h3>
+                              <p className={styles.calendarItemTextP}>
+                                {milestone.time}
+                              </p>
                             </div>
                           </div>
                         ))}
@@ -310,53 +468,70 @@ export default function PartnerPage() {
                 </div>
               )}
 
-              {activeTab === 'customize' && (
+              {activeTab === "customize" && (
                 <div className={styles.tabContent}>
                   <div className={styles.card}>
                     <div className={styles.cardHeader}>
                       <h2 className={styles.cardTitle}>カスタマイズ</h2>
-                      <p className={styles.cardDescription}>あなたのパートナーをカスタマイズ</p>
+                      <p className={styles.cardDescription}>
+                        あなたのパートナーをカスタマイズ
+                      </p>
                     </div>
                     <div className={styles.cardContent}>
                       <div className={styles.formSection}>
                         <div className={styles.formField}>
-                          <label htmlFor="partnerName-input" className={styles.formLabel}>名前</label>
+                          <label
+                            htmlFor="partnerName-input"
+                            className={styles.formLabel}
+                          >
+                            名前
+                          </label>
                           <input
                             id="partnerName-input"
                             className={styles.formInput}
-                            value={partnerName}
-                            onChange={(e) => setPartnerName(e.target.value)}
+                            value={plant?.plant_name}
                           />
                         </div>
                         <div className={styles.formField}>
-                          <label htmlFor="partnerLevel-input" className={styles.formLabel}>レベル</label>
+                          <label
+                            htmlFor="partnerLevel-input"
+                            className={styles.formLabel}
+                          >
+                            レベル
+                          </label>
                           <input
                             type="number"
                             id="partnerLevel-input"
                             className={styles.formInput}
-                            value={partnerLevel}
-                            onChange={(e) => setPartnerLevel(parseInt(e.target.value, 10) || 0)}
+                            value={4}
                           />
                         </div>
                         <div className={styles.formField}>
-                          <label htmlFor="partnerGrowth-input" className={styles.formLabel}>成長度 (%)</label>
+                          <label
+                            htmlFor="partnerGrowth-input"
+                            className={styles.formLabel}
+                          >
+                            成長度 (%)
+                          </label>
                           <input
                             type="number"
                             id="partnerGrowth-input"
                             className={styles.formInput}
-                            value={partnerGrowth}
                             max="100"
                             min="0"
-                            onChange={(e) => setPartnerGrowth(Math.max(0, Math.min(100, parseInt(e.target.value, 10) || 0)))}
                           />
                         </div>
                         <div className={styles.formField}>
-                          <label htmlFor="partnerPersonality-select" className={styles.formLabel}>性格</label>
+                          <label
+                            htmlFor="partnerPersonality-select"
+                            className={styles.formLabel}
+                          >
+                            性格
+                          </label>
                           <select
                             id="partnerPersonality-select"
                             className={styles.formSelect}
-                            value={partnerPersonality}
-                            onChange={(e) => setPartnerPersonality(e.target.value)}
+                            value={plant?.mood}
                           >
                             <option value="励まし屋">励まし屋</option>
                             <option value="冷静沈着">冷静沈着</option>
@@ -368,7 +543,10 @@ export default function PartnerPage() {
                       </div>
                     </div>
                     <div className={styles.cardFooter}>
-                      <button onClick={handleSaveCustomization} className={styles.formButton}>
+                      <button
+                        onClick={handleSaveCustomization}
+                        className={styles.formButton}
+                      >
                         保存
                       </button>
                     </div>

--- a/src/routes/partner/setup/PartnerSetupPage.module.css
+++ b/src/routes/partner/setup/PartnerSetupPage.module.css
@@ -1,0 +1,673 @@
+/* UchinoKoSetupPage.module.css */
+
+/* Custom CSS Variables (mimicking shadcn/ui's base colors and common values) */
+:root {
+  /* Colors */
+  --background: #ffffff; /* White */
+  --foreground: #0c0a09; /* Near black */
+  --muted-foreground: #6b7280; /* Gray-500 */
+  --muted-background-50: rgba(243, 244, 246, 0.5); /* Gray-100 with opacity */
+  --border: #e5e7eb; /* Gray-200 */
+  --primary: #22c55e; /* Green-500 */
+  --primary-foreground: #f8fafc; /* Near white */
+  --primary-10: rgba(34, 197, 94, 0.1); /* Green-500 with 10% opacity */
+  --green-50: #f0fdf4; /* Light green */
+  --blue-50: #eff6ff; /* Light blue */
+  --pink-500: #ec4899; /* Pink-500 */
+  --yellow-500: #facc15; /* Yellow-500 */
+  --gray-200: #e5e7eb; /* Gray-200 */
+
+  /* Other palette colors for customization */
+  --color-blue: #3b82f6; /* Blue-500 */
+  --color-orange: #f59e0b; /* Orange-400 */
+  --color-red: #ef4444; /* Red-500 */
+  --color-purple: #8b5cf6; /* Purple-500 */
+  --color-pink: #ec4899; /* Pink-500 */
+
+  /* Spacing */
+  --spacing-1: 0.25rem; /* 4px */
+  --spacing-2: 0.5rem; /* 8px */
+  --spacing-3: 0.75rem; /* 12px */
+  --spacing-4: 1rem; /* 16px */
+  --spacing-6: 1.5rem; /* 24px */
+  --spacing-8: 2rem; /* 32px */
+  --spacing-p-8: 2rem; /* 32px for p-8 */
+  --spacing-px-4: 1rem; /* 16px for px-4 */
+  --spacing-py-8: 2rem; /* 32px for py-8 */
+  --spacing-mb-4: 1rem; /* 16px for mb-4 */
+  --spacing-mb-8: 2rem; /* 32px for mb-8 */
+  --spacing-mt-1: 0.25rem; /* 4px for mt-1 */
+  --spacing-mt-2: 0.5rem; /* 8px for mt-2 */
+  --spacing-mt-8: 2rem; /* 32px for mt-8 */
+}
+
+/* General Layout */
+.container {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+/* Header */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--border);
+  background-color: var(--background);
+}
+
+.headerContent {
+  display: flex;
+  height: 4rem; /* h-16 */
+  align-items: center;
+  justify-content: space-between;
+  padding-left: var(--spacing-px-4);
+  padding-right: var(--spacing-px-4);
+}
+
+.logoGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-6);
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  font-weight: 700;
+  font-size: 1.25rem; /* text-xl */
+  text-decoration: none; /* Link default styling */
+  color: var(--foreground); /* Default text color */
+}
+
+.logoPrimary {
+  color: var(--primary);
+}
+
+.headerIcons {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.iconButton {
+  background: none;
+  border: none;
+  padding: 0.5rem; /* Consistent padding for icon buttons */
+  cursor: pointer;
+  border-radius: 0.375rem; /* rounded-md */
+  transition: background-color 0.2s ease;
+}
+
+.iconButton:hover {
+  background-color: rgba(0, 0, 0, 0.05); /* Light hover effect */
+}
+
+.icon {
+  height: 1.25rem; /* h-5 */
+  width: 1.25rem; /* w-5 */
+  color: var(--muted-foreground); /* Default icon color */
+}
+
+.srOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
+
+/* Main Content Area */
+.mainContent {
+  flex: 1;
+  background: linear-gradient(to bottom right, var(--green-50), var(--blue-50));
+}
+
+.pageContainer {
+  padding-left: var(--spacing-px-4);
+  padding-right: var(--spacing-px-4);
+  padding-top: var(--spacing-py-8);
+  padding-bottom: var(--spacing-py-8);
+}
+
+.centeredContent {
+  max-width: 48rem; /* max-w-4xl */
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center; /* text-center */
+  margin-bottom: var(--spacing-mb-8);
+}
+
+.pageTitleGroup {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-2);
+  margin-bottom: var(--spacing-mb-4);
+}
+
+.heartIcon {
+  height: 2rem; /* h-8 */
+  width: 2rem; /* w-8 */
+  color: var(--pink-500);
+}
+
+.pageTitle {
+  font-size: 1.875rem; /* text-3xl */
+  font-weight: 700; /* font-bold */
+}
+
+.sparklesIcon {
+  height: 2rem; /* h-8 */
+  width: 2rem; /* w-8 */
+  color: var(--yellow-500);
+}
+
+.pageDescription {
+  color: var(--muted-foreground);
+}
+
+/* Progress Bar */
+.progressBarSection {
+  margin-bottom: var(--spacing-mb-8);
+}
+
+.progressBarHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--spacing-2);
+}
+
+.progressBarStepText {
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+}
+
+.progressBarCompletionText {
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+}
+
+.progressBarTrack {
+  width: 100%;
+  background-color: var(--gray-200);
+  border-radius: 9999px; /* rounded-full */
+  height: 0.5rem; /* h-2 */
+}
+
+.progressBarFill {
+  background-color: var(--primary);
+  height: 0.5rem; /* h-2 */
+  border-radius: 9999px; /* rounded-full */
+  transition: width 0.3s ease-in-out; /* transition-all duration-300 */
+}
+
+/* Grid Layout for Steps and Preview */
+.gridContainer {
+  display: grid;
+  gap: var(--spacing-8);
+}
+
+@media (min-width: 768px) { /* md breakpoint */
+  .gridContainer {
+    grid-template-columns: repeat(2, minmax(0, 1fr)); /* md:grid-cols-2 */
+  }
+}
+
+/* Card Styling */
+.card {
+  border: 1px solid var(--border);
+  border-radius: 0.5rem; /* rounded-lg */
+  background-color: var(--background);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06); /* shadow-sm equivalent */
+}
+
+.cardHeader {
+  padding: 1.5rem; /* p-6 */
+  border-bottom: 1px solid var(--border);
+}
+
+.cardTitle {
+  font-size: 1.25rem; /* text-xl */
+  font-weight: 600; /* font-semibold */
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2);
+  margin-bottom: 0.5rem; /* mb-2 */
+}
+
+.cardDescription {
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+}
+
+.cardContent {
+  padding: 1.5rem; /* p-6 */
+}
+
+.cardContentSpaceY {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4); /* space-y-4 */
+  padding: 1.5rem; /* p-6 */
+}
+
+.cardContentSpaceYLarge {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-6); /* space-y-6 */
+  padding: 1.5rem; /* p-6 */
+}
+
+/* Step Number Badge */
+.stepNumber {
+  display: flex;
+  height: 2rem; /* h-8 */
+  width: 2rem; /* w-8 */
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px; /* rounded-full */
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+}
+
+/* Input Group */
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.label {
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+  color: var(--foreground);
+}
+
+.input {
+  display: flex;
+  height: 2.5rem; /* h-10 */
+  width: auto;
+  border-radius: 0.375rem; /* rounded-md */
+  border: 1px solid var(--border);
+  background-color: var(--background);
+  padding: 0.625rem 0.75rem; /* px-3 py-2 */
+  font-size: 0.875rem; /* text-sm */
+  line-height: 1.25rem; /* leading-5 */
+  color: var(--foreground);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2); /* ring-2 primary/20 */
+}
+
+.input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.mutedText {
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+}
+
+/* Hint Box */
+.hintBox {
+  padding: var(--spacing-4);
+  background-color: var(--muted-background-50);
+  border-radius: 0.5rem; /* rounded-lg */
+}
+
+.hintTitle {
+  font-weight: 500; /* font-medium */
+  margin-bottom: var(--spacing-2);
+}
+
+.hintList {
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-1);
+  padding-left: 0; /* Remove default list padding */
+  list-style: none; /* Remove default list bullets */
+}
+
+/* Radio Group */
+.radioGroupSpaceY {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-4);
+}
+
+.radioItem {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--spacing-3);
+}
+
+.radioItemControl {
+  appearance: none;
+  width: 1rem; /* w-4 */
+  height: 1rem; /* h-4 */
+  border-radius: 9999px; /* rounded-full */
+  border: 1px solid var(--border);
+  background-color: var(--background);
+  flex-shrink: 0; /* Prevent shrinking */
+  margin-top: var(--spacing-1); /* mt-1 */
+  cursor: pointer;
+  position: relative;
+}
+
+.radioItemControl:checked {
+  border-color: var(--primary);
+  background-color: var(--primary);
+}
+
+.radioItemControl:checked::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 0.5rem; /* Smaller circle for checkmark */
+  height: 0.5rem; /* Smaller circle for checkmark */
+  border-radius: 9999px;
+  background-color: var(--primary-foreground);
+}
+
+.radioItemControl:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.2); /* ring-2 primary/20 */
+}
+
+.radioItemContent {
+  flex: 1;
+}
+
+.radioItemLabel {
+  display: block; /* Make label occupy full width */
+  cursor: pointer;
+}
+
+.radioItemIcon {
+  font-size: 1.5rem; /* text-2xl */
+  display: inline-block; /* Keep icon in line with text */
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}
+
+.radioItemName {
+  font-weight: 500; /* font-medium */
+  font-size: 1rem; /* Base size */
+  vertical-align: middle;
+}
+
+.radioItemDescription {
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+  margin-top: var(--spacing-1);
+}
+
+/* Trait Badges */
+.traitsContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-1);
+  margin-top: var(--spacing-2);
+}
+
+.traitBadge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 9999px; /* rounded-full */
+  background-color: var(--primary-10);
+  padding-left: var(--spacing-2);
+  padding-right: var(--spacing-2);
+  padding-top: var(--spacing-1);
+  padding-bottom: var(--spacing-1);
+  font-size: 0.75rem; /* text-xs */
+  font-weight: 500; /* font-medium */
+  color: var(--primary);
+}
+
+/* Color Picker & Swatch */
+.colorPickerGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.colorInput {
+  width: 3rem; /* w-12 */
+  height: 3rem; /* h-12 */
+  border-radius: 0.25rem; /* rounded */
+  border: 1px solid var(--border);
+  cursor: pointer;
+  padding: 0;
+  -webkit-appearance: none; /* Remove default browser styling */
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.colorInput::-webkit-color-swatch-wrapper {
+  padding: 0;
+}
+
+.colorInput::-webkit-color-swatch {
+  border: none;
+  border-radius: 0.25rem;
+}
+
+.colorPalette {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.colorSwatch {
+  width: 2rem; /* w-8 */
+  height: 2rem; /* h-8 */
+  border-radius: 9999px; /* rounded-full */
+  border: 2px solid white;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.colorSwatch:hover {
+  transform: scale(1.1);
+}
+
+/* Slider */
+.slider {
+  width: 100%;
+  -webkit-appearance: none; /* Remove default browser styling */
+  appearance: none;
+  height: 0.25rem; /* track height */
+  background: var(--gray-200);
+  border-radius: 0.25rem;
+  outline: none;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.slider:hover {
+  opacity: 1;
+}
+
+/* Thumb */
+.slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1rem; /* w-4 */
+  height: 1rem; /* h-4 */
+  border-radius: 9999px; /* rounded-full */
+  background: var(--primary);
+  cursor: grab;
+  margin-top: -0.375rem; /* Center thumb on track */
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.1);
+}
+
+.slider::-moz-range-thumb {
+  width: 1rem; /* w-4 */
+  height: 1rem; /* h-4 */
+  border-radius: 9999px; /* rounded-full */
+  background: var(--primary);
+  cursor: grab;
+  border: none; /* Remove default border */
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.1);
+}
+
+.sliderLabels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+}
+
+/* Plant Preview */
+.plantPreviewContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-p-8);
+}
+
+.plantPreviewOuter {
+  position: relative;
+  margin-bottom: var(--spacing-4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px; /* rounded-full */
+}
+
+.plantPreviewInner {
+  border-radius: 9999px; /* rounded-full */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.25rem; /* text-4xl */
+  color: var(--background); /* Icon color inside colored circle */
+}
+
+.plantName {
+  font-size: 1.125rem; /* text-lg */
+  font-weight: 500; /* font-medium */
+  margin-bottom: var(--spacing-1);
+}
+
+.plantPersonality {
+  font-size: 0.875rem; /* text-sm */
+  color: var(--muted-foreground);
+}
+
+.stickyCard {
+  position: sticky;
+  top: 6rem; /* top-24 */
+}
+
+/* Navigation Buttons */
+.navigationButtons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: var(--spacing-mt-8);
+}
+
+.buttonGroup {
+  display: flex;
+  gap: var(--spacing-2);
+}
+
+.buttonBase {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.625rem 1rem; /* px-4 py-2.5, roughly h-10 */
+  font-size: 0.875rem; /* text-sm */
+  font-weight: 500; /* font-medium */
+  border-radius: 0.375rem; /* rounded-md */
+  cursor: pointer;
+  transition: background-color 0.2s ease, opacity 0.2s ease;
+  text-decoration: none; /* For Link component */
+  white-space: nowrap; /* Prevent text wrap */
+}
+
+.buttonPrimary {
+  composes: buttonBase;
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border: 1px solid var(--primary);
+}
+
+.buttonPrimary:hover:not(:disabled) {
+  background-color: var(--green-600); /* Darker primary for hover */
+  border-color: var(--green-600);
+}
+
+.buttonOutline {
+  composes: buttonBase;
+  background-color: var(--background);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+}
+
+.buttonOutline:hover:not(:disabled) {
+  background-color: var(--gray-100); /* Lighter background for hover */
+}
+
+.buttonDisabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.buttonIcon {
+  margin-left: var(--spacing-2);
+  height: 1rem; /* h-4 */
+  width: 1rem; /* w-4 */
+}
+
+/* Ensure consistent button sizes for shadcn/ui Button replacements */
+.buttonBase {
+  height: 2.5rem; /* h-10 */
+  min-width: 2.5rem; /* for icon buttons if needed */
+}
+
+
+.infoMessage {
+  text-align: center;
+  margin-top: 1rem;
+  color: #3b82f6; /* Blue-500 */
+  font-weight: 500;
+}
+
+.errorMessage {
+  text-align: center;
+  margin-top: 1rem;
+  color: #ef4444; /* Red-500 */
+  font-weight: 500;
+}
+
+/* ボタンのdisabled状態のスタイルも改善 */
+.buttonPrimary:disabled,
+.buttonOutline:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.buttonDisabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  pointer-events: none; /* Linkコンポーネントがクリックできないようにする */
+}

--- a/src/routes/partner/setup/PartnerSetupPage.tsx
+++ b/src/routes/partner/setup/PartnerSetupPage.tsx
@@ -1,0 +1,415 @@
+"use client"
+
+import { useState } from "react"
+import { useNavigate } from "react-router-dom" // useNavigateをインポート
+import { FaArrowRight, FaHeart, FaMagic } from "react-icons/fa"
+
+import styles from "./PartnerSetupPage.module.css"
+import { useRegisterPlant } from "../../../hooks/usePlant" // useRegisterPlantフックをインポート
+import { plantTypes, personalities } from "../../../types/plantType";
+
+export default function UchinoKoSetupPage() {
+  const [step, setStep] = useState(1)
+  const [plantName, setPlantName] = useState("")
+  const [plantType, setPlantType] = useState("")
+  const [personality, setPersonality] = useState("")
+  const [color, setColor] = useState("#22c55e")
+  const [size, setSize] = useState(50)
+  const [motivation, setMotivation] = useState("")
+
+  // useRegisterPlantフックを使用
+  const { loading, error, registerPlant } = useRegisterPlant();
+  const navigate = useNavigate(); // 遷移のためにuseNavigateを初期化
+
+
+  const motivationTypes = [
+    {
+      id: "achievement",
+      name: "達成感重視",
+      description: "目標達成や課題クリアを重視したサポート",
+    },
+    {
+      id: "learning",
+      name: "学習プロセス重視",
+      description: "学習過程や理解度を重視したサポート",
+    },
+    {
+      id: "social",
+      name: "コミュニティ重視",
+      description: "他の学習者との交流を重視したサポート",
+    },
+    {
+      id: "balance",
+      name: "バランス重視",
+      description: "学習と休息のバランスを重視したサポート",
+    },
+  ]
+
+  const nextStep = () => {
+    if (step < 5) {
+      setStep(step + 1)
+    }
+  }
+
+  const prevStep = () => {
+    if (step > 1) {
+      setStep(step - 1)
+    }
+  }
+
+  const canProceed = () => {
+    switch (step) {
+      case 1:
+        return plantName.trim() !== ""
+      case 2:
+        return plantType !== ""
+      case 3:
+        return personality !== ""
+      case 4:
+        return true // カスタマイズは任意
+      case 5:
+        return motivation !== ""
+      default:
+        return false
+    }
+  }
+
+  // 登録処理ハンドラ
+  const handleRegisterPlant = async () => {
+    if (!canProceed()) return; // 最終ステップの条件を満たしていない場合は何もしない
+
+    const plantData = {
+      growth_stage: plantType, // plantTypeをgrowth_stageにマッピング
+      mood: personality,       // personalityをmoodにマッピング
+      plant_name: plantName,
+      color: color,
+      size: size,
+      motivation_style: motivation,
+    };
+
+    await registerPlant(plantData);
+
+    // 登録成功時に次のページへ遷移
+    if (!error) {
+      navigate("/partner");
+    }
+  };
+
+
+  const getPlantPreview = () => {
+    const selectedType = plantTypes.find((type) => type.id === plantType)
+    return (
+      <div className={styles.plantPreviewContainer}>
+        <div
+          className={styles.plantPreviewOuter}
+          style={{
+            width: `${size + 50}px`,
+            height: `${size + 50}px`,
+            backgroundColor: `${color}20`,
+          }}
+        >
+          <div
+            className={styles.plantPreviewInner}
+            style={{
+              width: `${size}px`,
+              height: `${size}px`,
+              backgroundColor: color,
+            }}
+          >
+            {selectedType?.icon || "🌱"}
+          </div>
+        </div>
+        <h3 className={styles.plantName}>{plantName || "名前未設定"}</h3>
+        <p className={styles.plantPersonality}>
+          {personalities.find((p) => p.id === personality)?.name || "性格未設定"}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.container}>
+      <main className={styles.mainContent}>
+        <div className={styles.pageContainer}>
+          <div className={styles.centeredContent}>
+            <div className={styles.pageTitleGroup}>
+              <FaHeart className={styles.heartIcon} />
+              <h1 className={styles.pageTitle}>うちのコを作ろう！</h1>
+              <FaMagic className={styles.sparklesIcon} />
+            </div>
+            <p className={styles.pageDescription}>
+              あなたの学習パートナーとなる「うちのコ」を作成しましょう。一緒に成長していく特別な存在です。
+            </p>
+          </div>
+
+          {/* プログレスバー */}
+          <div className={styles.progressBarSection}>
+            <div className={styles.progressBarHeader}>
+              <span className={styles.progressBarStepText}>ステップ {step} / 5</span>
+              <span className={styles.progressBarCompletionText}>{Math.round((step / 5) * 100)}% 完了</span>
+            </div>
+            <div className={styles.progressBarTrack}>
+              <div
+                className={styles.progressBarFill}
+                style={{ width: `${(step / 5) * 100}%` }}
+              />
+            </div>
+          </div>
+
+          <div className={styles.gridContainer}>
+            <div>
+              {/* ステップ1: 名前設定 */}
+              {step === 1 && (
+                <div className={styles.card}>
+                  <div className={styles.cardHeader}>
+                    <h2 className={styles.cardTitle}>
+                      <span className={styles.stepNumber}>1</span>
+                      うちのコの名前を決めよう
+                    </h2>
+                    <p className={styles.cardDescription}>あなたのパートナーにぴったりの名前を付けてください</p>
+                  </div>
+                  <div className={styles.cardContentSpaceY}>
+                    <div className={styles.inputGroup}>
+                      <label htmlFor="plantName" className={styles.label}>名前</label>
+                      <input
+                        id="plantName"
+                        type="text"
+                        placeholder="例: モリモリ、ピカピカ、すくすく"
+                        value={plantName}
+                        onChange={(e) => setPlantName(e.target.value)}
+                        maxLength={10}
+                        className={styles.input}
+                      />
+                      <p className={styles.mutedText}>10文字以内で入力してください</p>
+                    </div>
+                    <div className={styles.hintBox}>
+                      <h4 className={styles.hintTitle}>💡 名前のヒント</h4>
+                      <ul className={styles.hintList}>
+                        <li>• 覚えやすくて親しみやすい名前がおすすめ</li>
+                        <li>• 成長や学習に関連する言葉も素敵です</li>
+                        <li>• 後から変更することもできます</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* ステップ2: 種類選択 */}
+              {step === 2 && (
+                <div className={styles.card}>
+                  <div className={styles.cardHeader}>
+                    <h2 className={styles.cardTitle}>
+                      <span className={styles.stepNumber}>2</span>
+                      うちのコの種類を選ぼう
+                    </h2>
+                    <p className={styles.cardDescription}>それぞれ異なる特徴を持っています</p>
+                  </div>
+                  <div className={styles.cardContent}>
+                    <div className={styles.radioGroupSpaceY}>
+                      {plantTypes.map((type) => (
+                        <div key={type.id} className={styles.radioItem}>
+                          <input
+                            type="radio"
+                            id={type.id}
+                            name="plantType"
+                            value={type.id}
+                            checked={plantType === type.id}
+                            onChange={(e) => setPlantType(e.target.value)}
+                            className={styles.radioItemControl}
+                          />
+                          <div className={styles.radioItemContent}>
+                            <label htmlFor={type.id} className={styles.radioItemLabel}>
+                              <span className={styles.radioItemIcon}>{type.icon}</span>
+                              <span className={styles.radioItemName}>{type.name}</span>
+                            </label>
+                            <p className={styles.radioItemDescription}>{type.description}</p>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* ステップ3: 性格選択 */}
+              {step === 3 && (
+                <div className={styles.card}>
+                  <div className={styles.cardHeader}>
+                    <h2 className={styles.cardTitle}>
+                      <span className={styles.stepNumber}>3</span>
+                      性格を選ぼう
+                    </h2>
+                    <p className={styles.cardDescription}>うちのコがどんな風にサポートしてくれるかが決まります</p>
+                  </div>
+                  <div className={styles.cardContent}>
+                    <div className={styles.radioGroupSpaceY}>
+                      {personalities.map((p) => (
+                        <div key={p.id} className={styles.radioItem}>
+                          <input
+                            type="radio"
+                            id={p.id}
+                            name="personality"
+                            value={p.id}
+                            checked={personality === p.id}
+                            onChange={(e) => setPersonality(e.target.value)}
+                            className={styles.radioItemControl}
+                          />
+                          <div className={styles.radioItemContent}>
+                            <label htmlFor={p.id} className={styles.radioItemLabel}>
+                              <div className={styles.radioItemName}>{p.name}</div>
+                              <p className={styles.radioItemDescription}>{p.description}</p>
+                              <div className={styles.traitsContainer}>
+                                {p.traits.map((trait) => (
+                                  <span
+                                    key={trait}
+                                    className={styles.traitBadge}
+                                  >
+                                    {trait}
+                                  </span>
+                                ))}
+                              </div>
+                            </label>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* ステップ4: カスタマイズ */}
+              {step === 4 && (
+                <div className={styles.card}>
+                  <div className={styles.cardHeader}>
+                    <h2 className={styles.cardTitle}>
+                      <span className={styles.stepNumber}>4</span>
+                      見た目をカスタマイズ
+                    </h2>
+                    <p className={styles.cardDescription}>色やサイズを調整して、あなただけのうちのコに</p>
+                  </div>
+                  <div className={styles.cardContentSpaceYLarge}>
+                    <div className={styles.inputGroup}>
+                      <label htmlFor="color" className={styles.label}>色</label>
+                      <div className={styles.colorPickerGroup}>
+                        <input
+                          type="color"
+                          id="color"
+                          value={color}
+                          onChange={(e) => setColor(e.target.value)}
+                          className={styles.colorInput}
+                        />
+                        <div className={styles.colorPalette}>
+                          {["#22c55e", "#3b82f6", "#f59e0b", "#ef4444", "#8b5cf6", "#ec4899"].map((c) => (
+                            <button
+                              key={c}
+                              type="button"
+                              onClick={() => setColor(c)}
+                              className={styles.colorSwatch}
+                              style={{ backgroundColor: c }}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                    <div className={styles.inputGroup}>
+                      <label htmlFor="size" className={styles.label}>サイズ</label>
+                      <input
+                        type="range"
+                        id="size"
+                        min={30}
+                        max={80}
+                        step={5}
+                        value={size}
+                        onChange={(e) => setSize(parseInt(e.target.value))}
+                        className={styles.slider}
+                      />
+                      <div className={styles.sliderLabels}>
+                        <span>小さい</span>
+                        <span>大きい</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* ステップ5: 学習スタイル */}
+              {step === 5 && (
+                <div className={styles.card}>
+                  <div className={styles.cardHeader}>
+                    <h2 className={styles.cardTitle}>
+                      <span className={styles.stepNumber}>5</span>
+                      学習スタイルを選ぼう
+                    </h2>
+                    <p className={styles.cardDescription}>うちのコがどんな風にサポートするかを決めます</p>
+                  </div>
+                  <div className={styles.cardContent}>
+                    <div className={styles.radioGroupSpaceY}>
+                      {motivationTypes.map((type) => (
+                        <div key={type.id} className={styles.radioItem}>
+                          <input
+                            type="radio"
+                            id={type.id}
+                            name="motivation"
+                            value={type.id}
+                            checked={motivation === type.id}
+                            onChange={(e) => setMotivation(e.target.value)}
+                            className={styles.radioItemControl}
+                          />
+                          <div className={styles.radioItemContent}>
+                            <label htmlFor={type.id} className={styles.radioItemLabel}>
+                              <div className={styles.radioItemName}>{type.name}</div>
+                              <p className={styles.radioItemDescription}>{type.description}</p>
+                            </label>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    {/* 登録処理中のフィードバック */}
+                    {loading && <p className={styles.infoMessage}>うちのコを登録中...</p>}
+                    {error && <p className={styles.errorMessage}>エラー: {error}</p>}
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* プレビュー */}
+            <div>
+              <div className={styles.stickyCard}>
+                <div className={styles.cardHeader}>
+                  <h2 className={styles.cardTitle}>プレビュー</h2>
+                  <p className={styles.cardDescription}>あなたのうちのコはこんな感じになります</p>
+                </div>
+                <div className={styles.cardContent}>{getPlantPreview()}</div>
+              </div>
+            </div>
+          </div>
+
+          {/* ナビゲーションボタン */}
+          <div className={styles.navigationButtons}>
+            <button type="button" className={styles.buttonOutline} onClick={prevStep} disabled={step === 1 || loading}>
+              戻る
+            </button>
+            <div className={styles.buttonGroup}>
+              {step < 5 ? (
+                <button type="button" className={styles.buttonPrimary} onClick={nextStep} disabled={!canProceed() || loading}>
+                  次へ
+                  <FaArrowRight className={styles.buttonIcon} />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  className={styles.buttonPrimary}
+                  onClick={handleRegisterPlant}
+                  disabled={!canProceed() || loading}
+                >
+                  完了！うちのコと始める
+                  <FaHeart className={styles.buttonIcon} />
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/types/notificationType.ts
+++ b/src/types/notificationType.ts
@@ -1,9 +1,13 @@
 export type Notification = {
     notification_id: string;
-    user_id: string;
+    type: string;
+    title: string;
     message: string;
+    detail: string;
     is_read: boolean;
     created_at: Date;
+    priority: string;
+    actionUrl?: string;
 }
 
 export type Unread = {

--- a/src/types/plantType.ts
+++ b/src/types/plantType.ts
@@ -3,5 +3,63 @@ export type Plant = {
     user_id: string;
     growth_stage: string;
     mood: string;
+    plant_name: string;
+    color: string;
+    size: number;
+    motivation_style: string;
     last_updated: Date;
 }
+
+export const plantTypes = [
+    {
+      id: "sprout",
+      name: "新芽",
+      description: "小さくて可愛い新芽。成長が早く、励ましが得意です。",
+      icon: "🌱",
+    },
+    {
+      id: "flower",
+      name: "花",
+      description: "美しい花を咲かせます。創造性を刺激してくれます。",
+      icon: "🌸",
+    },
+    {
+      id: "tree",
+      name: "木",
+      description: "しっかりとした木。安定感があり、長期的な目標達成をサポートします。",
+      icon: "🌳",
+    },
+    {
+      id: "cactus",
+      name: "サボテン",
+      description: "たくましいサボテン。困難に立ち向かう力を与えてくれます。",
+      icon: "🌵",
+    },
+  ]
+
+export const personalities = [
+    {
+      id: "cheerful",
+      name: "明るい励まし屋",
+      description: "いつも前向きで、あなたを元気づけてくれます。",
+      traits: ["励まし上手", "ポジティブ", "エネルギッシュ"],
+    },
+    {
+      id: "calm",
+      name: "冷静なアドバイザー",
+      description: "落ち着いていて、的確なアドバイスをくれます。",
+      traits: ["論理的", "冷静", "分析力"],
+    },
+    {
+      id: "gentle",
+      name: "優しい癒し系",
+      description: "温かく見守り、疲れた時に癒してくれます。",
+      traits: ["優しい", "共感力", "癒し"],
+    },
+    {
+      id: "strict",
+      name: "厳しいコーチ",
+      description: "時には厳しく、あなたの成長を促してくれます。",
+      traits: ["規律正しい", "目標志向", "成長重視"],
+    },
+  ]


### PR DESCRIPTION
- Implemented PartnerSetupPage component with steps for naming, selecting type, personality, customization, and learning style.
- Created PartnerSetupPage.module.css for styling, including custom CSS variables and responsive design.
- Added plant types and personalities data structures to support user selections.
- Integrated useRegisterPlant hook for plant registration functionality.
- Enhanced notificationType and plantType definitions to include additional properties.